### PR TITLE
Add support for multiple filters

### DIFF
--- a/src/commands/custom_command.ts
+++ b/src/commands/custom_command.ts
@@ -21,9 +21,30 @@ export class CustomCommand extends Command {
 
       const filters: {[key: string]: string} = {}
       const dashboardFilters = dashboard.dashboard_filters || dashboard.filters
-      for (const filter of dashboardFilters) {
-        filters[filter.name] = query
+
+      // Parse query into multiple filter parts, optionally quoted
+      var queryParts = []
+      if (dashboardFilters.length === 1) {
+        // Special convenience case for single-filter dashboards
+        queryParts.push(query)
+      } else {
+        const splitRegex  = /[^\s"]+|"([^"]*)"/g
+        do {
+            var match = splitRegex.exec(query)
+            if (match != null)
+            {
+                queryParts.push(match[1] ? match[1] : match[0])
+            }
+        } while (match != null)
       }
+
+      const commonLength = Math.min(dashboardFilters.length, queryParts.length)
+      for (var i = 0; i < commonLength; i++) {
+        const filter = dashboardFilters[i]
+        const queryPart = queryParts[i]
+        filters[filter.name] = queryPart
+      }
+
       const runner = new DashboardQueryRunner(context, matchedCommand.dashboard, filters)
       runner.start()
 


### PR DESCRIPTION
The original maintainers haven't added this because they can't agree on a syntax.  We don't care that much; just support simple space-delimited values, optionally quoted (with no special escaping or single-quote support).  I.e.

```
/looker some-report These are "some arguments"
```

We can always change later. Sorry my javascript is terrible; definitely stole some stuff from stackoverflow for the regex part 🙃 